### PR TITLE
Don't pass output-only arguments to GenerateCommandValidator

### DIFF
--- a/src/Model/GenerateCommandErrorOutput.php
+++ b/src/Model/GenerateCommandErrorOutput.php
@@ -6,6 +6,11 @@ namespace webignition\BasilRunner\Model;
 
 class GenerateCommandErrorOutput extends AbstractGenerateCommandOutput implements \JsonSerializable
 {
+    public const ERROR_CODE_SOURCE_EMPTY = 1;
+    public const ERROR_CODE_SOURCE_INVALID_DOES_NOT_EXIST = 2;
+    public const ERROR_CODE_SOURCE_INVALID_NOT_A_FILE = 3;
+    public const ERROR_CODE_SOURCE_INVALID_NOT_READABLE = 4;
+
     private $errorMessage;
 
     public function __construct(string $source, string $target, string $errorMessage)

--- a/src/Model/ValidationResult/Command/GenerateCommandValidationResult.php
+++ b/src/Model/ValidationResult/Command/GenerateCommandValidationResult.php
@@ -4,24 +4,15 @@ declare(strict_types=1);
 
 namespace webignition\BasilRunner\Model\ValidationResult\Command;
 
-use webignition\BasilRunner\Model\GenerateCommandErrorOutput;
-
 class GenerateCommandValidationResult
 {
     private $isValid;
-    private $errorOutput;
-    private $exitCode;
+    private $errorCode;
 
-    public function __construct(bool $isValid, ?GenerateCommandErrorOutput $errorOutput = null, int $exitCode = 0)
+    public function __construct(bool $isValid, int $exitCode = 0)
     {
         $this->isValid = $isValid;
-        $this->exitCode = $exitCode;
-
-        if ($errorOutput instanceof GenerateCommandErrorOutput) {
-            $this->errorOutput = $errorOutput;
-        } else {
-            $this->errorOutput = new GenerateCommandErrorOutput('', '', '');
-        }
+        $this->errorCode = $exitCode;
     }
 
     public function getIsValid(): bool
@@ -29,13 +20,8 @@ class GenerateCommandValidationResult
         return $this->isValid;
     }
 
-    public function getErrorOutput(): GenerateCommandErrorOutput
+    public function getErrorCode(): int
     {
-        return $this->errorOutput;
-    }
-
-    public function getExitCode(): int
-    {
-        return $this->exitCode;
+        return $this->errorCode;
     }
 }

--- a/src/Services/Validator/Command/GenerateCommandValidator.php
+++ b/src/Services/Validator/Command/GenerateCommandValidator.php
@@ -9,69 +9,36 @@ use webignition\BasilRunner\Model\ValidationResult\Command\GenerateCommandValida
 
 class GenerateCommandValidator
 {
-    private const EXIT_CODE_SOURCE_EMPTY = 1;
-    private const EXIT_CODE_SOURCE_INVALID_DOES_NOT_EXIST = 2;
-    private const EXIT_CODE_SOURCE_INVALID_NOT_A_FILE = 3;
-    private const EXIT_CODE_SOURCE_INVALID_NOT_READABLE = 4;
-
-    public function validateSource(?string $source, ?string $target, string $rawSource)
+    public function validateSource(?string $source, string $rawSource)
     {
         if (null === $source) {
             if ('' === $rawSource) {
                 return new GenerateCommandValidationResult(
                     false,
-                    $this->createErrorOutput(
-                        $source,
-                        $target,
-                        'source empty; call with --source=SOURCE'
-                    ),
-                    self::EXIT_CODE_SOURCE_EMPTY
+                    GenerateCommandErrorOutput::ERROR_CODE_SOURCE_EMPTY
                 );
             }
 
             return new GenerateCommandValidationResult(
                 false,
-                $this->createErrorOutput(
-                    $source,
-                    $target,
-                    'source invalid; does not exist'
-                ),
-                self::EXIT_CODE_SOURCE_INVALID_DOES_NOT_EXIST
+                GenerateCommandErrorOutput::ERROR_CODE_SOURCE_INVALID_DOES_NOT_EXIST
             );
         }
 
         if (!is_file($source)) {
             return new GenerateCommandValidationResult(
                 false,
-                $this->createErrorOutput(
-                    $source,
-                    $target,
-                    'source invalid; is not a file (is it a directory?)'
-                ),
-                self::EXIT_CODE_SOURCE_INVALID_NOT_A_FILE
+                GenerateCommandErrorOutput::ERROR_CODE_SOURCE_INVALID_NOT_A_FILE
             );
         }
 
         if (!is_readable($source)) {
             return new GenerateCommandValidationResult(
                 false,
-                $this->createErrorOutput(
-                    $source,
-                    $target,
-                    'source invalid; file is not readable'
-                ),
-                self::EXIT_CODE_SOURCE_INVALID_NOT_READABLE
+                GenerateCommandErrorOutput::ERROR_CODE_SOURCE_INVALID_NOT_READABLE
             );
         }
 
         return new GenerateCommandValidationResult(true);
-    }
-
-    private function createErrorOutput(
-        ?string $source,
-        ?string $target,
-        string $errorMessage
-    ): GenerateCommandErrorOutput {
-        return new GenerateCommandErrorOutput((string) $source, (string) $target, $errorMessage);
     }
 }

--- a/tests/Unit/Services/Validator/Command/GenerateCommandValidatorTest.php
+++ b/tests/Unit/Services/Validator/Command/GenerateCommandValidatorTest.php
@@ -24,12 +24,11 @@ class GenerateCommandValidatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testValidateSource(
         ?string $source,
-        ?string $target,
         string $rawSource,
         GenerateCommandValidationResult $expectedResult
     ) {
         $validator = new GenerateCommandValidator();
-        $result = $validator->validateSource($source, $target, $rawSource);
+        $result = $validator->validateSource($source, $rawSource);
 
         $this->assertEquals($expectedResult, $result);
     }
@@ -41,50 +40,31 @@ class GenerateCommandValidatorTest extends \PHPUnit\Framework\TestCase
         return [
             'source exists, is a file, is readable' => [
                 'source' => $root . '/tests/Fixtures/basil/Test/example.com.verify-open-literal.yml',
-                'target' => $root . '/tests/build/target',
                 'rawSource' => 'tests/Fixtures/basil/Test/example.com.verify-open-literal.yml',
                 'expectedResult' => new GenerateCommandValidationResult(true)
             ],
-            'source missing' => [
+            'source empty' => [
                 'source' => null,
-                'target' => $root . '/tests/build/target',
                 'rawSource' => '',
                 'expectedResult' => new GenerateCommandValidationResult(
                     false,
-                    new GenerateCommandErrorOutput(
-                        '',
-                        $root . '/tests/build/target',
-                        'source empty; call with --source=SOURCE'
-                    ),
-                    1
+                    GenerateCommandErrorOutput::ERROR_CODE_SOURCE_EMPTY
                 )
             ],
             'source does not exist, target valid' => [
                 'source' => null,
-                'target' => $root . '/tests/build/target',
                 'rawSource' => '/tests/Fixtures/basil/Test/non-existent.yml',
                 'expectedResult' => new GenerateCommandValidationResult(
                     false,
-                    new GenerateCommandErrorOutput(
-                        '',
-                        $root . '/tests/build/target',
-                        'source invalid; does not exist'
-                    ),
-                    2
+                    GenerateCommandErrorOutput::ERROR_CODE_SOURCE_INVALID_DOES_NOT_EXIST
                 ),
             ],
             'source not a file, is a directory' => [
                 'source' => $root . '/tests/Fixtures/basil/Test/',
-                'target' => $root . '/tests/build/target',
                 'rawSource' => '/tests/Fixtures/basil/Test/non-existent.yml',
                 'expectedResult' => new GenerateCommandValidationResult(
                     false,
-                    new GenerateCommandErrorOutput(
-                        $root . '/tests/Fixtures/basil/Test/',
-                        $root . '/tests/build/target',
-                        'source invalid; is not a file (is it a directory?)'
-                    ),
-                    3
+                    GenerateCommandErrorOutput::ERROR_CODE_SOURCE_INVALID_NOT_A_FILE
                 ),
             ],
         ];
@@ -95,23 +75,17 @@ class GenerateCommandValidatorTest extends \PHPUnit\Framework\TestCase
         $root = (new ProjectRootPathProvider())->get();
 
         $source = $root . '/tests/Fixtures/basil/Test/example.com.verify-open-literal.yml';
-        $target = $root . '/tests/build/target';
         $rawSource = 'tests/Fixtures/basil/Test/example.com.verify-open-literal.yml';
 
         $validator = new GenerateCommandValidator();
 
         PHPMockery::mock('webignition\BasilRunner\Services\Validator\Command', 'is_readable')->andReturn(false);
 
-        $result = $validator->validateSource($source, $target, $rawSource);
+        $result = $validator->validateSource($source, $rawSource);
 
         $expectedResult = new GenerateCommandValidationResult(
             false,
-            new GenerateCommandErrorOutput(
-                $source,
-                $target,
-                'source invalid; file is not readable'
-            ),
-            4
+            GenerateCommandErrorOutput::ERROR_CODE_SOURCE_INVALID_NOT_READABLE
         );
 
         $this->assertEquals($expectedResult, $result);


### PR DESCRIPTION
Fixes #32