### PR TITLE
Use underscores as word separators in error output context keys

### DIFF
--- a/src/Services/GenerateCommand/ErrorOutputFactory.php
+++ b/src/Services/GenerateCommand/ErrorOutputFactory.php
@@ -193,7 +193,7 @@ class ErrorOutputFactory
                 'test' => $invalidPageException->getTestPath(),
                 'import_name' => $invalidPageException->getImportName(),
                 'path' => $invalidPageException->getPath(),
-                'validation-result' => $this->validatorInvalidResultSerializer->serializeToArray(
+                'validation_result' => $this->validatorInvalidResultSerializer->serializeToArray(
                     $invalidPageException->getValidationResult()
                 )
             ]
@@ -210,7 +210,7 @@ class ErrorOutputFactory
             ErrorOutput::CODE_LOADER_INVALID_TEST,
             [
                 'path' => $invalidTestException->getPath(),
-                'validation-result' => $this->validatorInvalidResultSerializer->serializeToArray(
+                'validation_result' => $this->validatorInvalidResultSerializer->serializeToArray(
                     $invalidTestException->getValidationResult()
                 )
             ]
@@ -239,7 +239,7 @@ class ErrorOutputFactory
                 'type' => $nonRetrievableImportException->getType(),
                 'name' => $nonRetrievableImportException->getName(),
                 'path' => $nonRetrievableImportException->getPath(),
-                'loader-error' => [
+                'loader_error' => [
                     'message' => $loaderMessage,
                     'path' => $yamlLoaderException->getPath(),
                 ]
@@ -279,7 +279,7 @@ class ErrorOutputFactory
 
             $code = $unparseableStatementException->getCode();
 
-            $context['statement-type'] = $statementType;
+            $context['statement_type'] = $statementType;
             $context['statement'] = $unparseableStatementException->getStatement();
             $context['reason'] = $this->unparseableStatementErrorMessages[$statementType][$code] ?? 'unknown';
         }

--- a/tests/Functional/Command/GenerateCommandTest.php
+++ b/tests/Functional/Command/GenerateCommandTest.php
@@ -427,7 +427,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'test' => $testAbsolutePath,
                         'import_name' => 'empty_url_page',
                         'path' => $pageAbsolutePath,
-                        'validation-result' => [
+                        'validation_result' => [
                             'type' => 'page',
                             'reason' => 'page-url-empty',
                         ],
@@ -452,7 +452,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'test' => $testAbsolutePath,
                         'import_name' => 'empty_url_page',
                         'path' => $pageAbsolutePath,
-                        'validation-result' => [
+                        'validation_result' => [
                             'type' => 'page',
                             'reason' => 'page-url-empty',
                         ],
@@ -491,7 +491,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                     ErrorOutput::CODE_LOADER_INVALID_TEST,
                     [
                         'path' => $testAbsolutePath,
-                        'validation-result' => [
+                        'validation_result' => [
                             'type' => 'test',
                             'reason' => 'test-configuration-invalid',
                             'previous' => [
@@ -520,7 +520,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                     ErrorOutput::CODE_LOADER_INVALID_TEST,
                     [
                         'path' => $testAbsolutePath,
-                        'validation-result' => [
+                        'validation_result' => [
                             'type' => 'test',
                             'reason' => 'test-configuration-invalid',
                             'previous' => [
@@ -567,7 +567,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'type' => 'page',
                         'name' => 'unparseable_page',
                         'path' => $pageAbsolutePath,
-                        'loader-error' => [
+                        'loader_error' => [
                             'message' => 'Malformed inline YAML string: "http://example.com at line 2.',
                             'path' => $pageAbsolutePath,
                         ],
@@ -593,7 +593,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'type' => 'page',
                         'name' => 'unparseable_page',
                         'path' => $pageAbsolutePath,
-                        'loader-error' => [
+                        'loader_error' => [
                             'message' => 'Malformed inline YAML string: "http://example.com at line 2.',
                             'path' => $pageAbsolutePath,
                         ],
@@ -626,7 +626,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'type' => 'test',
                         'test_path' => $root . '/tests/Fixtures/basil/InvalidTest/unparseable-action.yml',
                         'step_name' => 'contains unparseable action',
-                        'statement-type' => 'action',
+                        'statement_type' => 'action',
                         'statement' => 'click invalid-identifier',
                         'reason' => 'invalid-identifier',
 
@@ -651,7 +651,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'type' => 'test',
                         'test_path' => $root . '/tests/Fixtures/basil/InvalidTest/unparseable-assertion.yml',
                         'step_name' => 'contains unparseable assertion',
-                        'statement-type' => 'assertion',
+                        'statement_type' => 'assertion',
                         'statement' => '$page.url is',
                         'reason' => 'empty-value',
 
@@ -676,7 +676,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'type' => 'step',
                         'test_path' => $root . '/tests/Fixtures/basil/InvalidTest/import-unparseable-action.yml',
                         'step_path' => $root . '/tests/Fixtures/basil/Step/unparseable-action.yml',
-                        'statement-type' => 'action',
+                        'statement_type' => 'action',
                         'statement' => 'click invalid-identifier',
                         'reason' => 'invalid-identifier',
 
@@ -701,7 +701,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'type' => 'step',
                         'test_path' => $root . '/tests/Fixtures/basil/InvalidTest/import-unparseable-assertion.yml',
                         'step_path' => $root . '/tests/Fixtures/basil/Step/unparseable-assertion.yml',
-                        'statement-type' => 'assertion',
+                        'statement_type' => 'assertion',
                         'statement' => '$page.url is',
                         'reason' => 'empty-value',
 
@@ -726,7 +726,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'type' => 'test',
                         'test_path' => $root . '/tests/Fixtures/basil/InvalidTest/unparseable-action.yml',
                         'step_name' => 'contains unparseable action',
-                        'statement-type' => 'action',
+                        'statement_type' => 'action',
                         'statement' => 'click invalid-identifier',
                         'reason' => 'invalid-identifier',
 
@@ -751,7 +751,7 @@ class GenerateCommandTest extends AbstractFunctionalTest
                         'type' => 'step',
                         'test_path' => $root . '/tests/Fixtures/basil/InvalidTest/import-unparseable-action.yml',
                         'step_path' => $root . '/tests/Fixtures/basil/Step/unparseable-action.yml',
-                        'statement-type' => 'action',
+                        'statement_type' => 'action',
                         'statement' => 'click invalid-identifier',
                         'reason' => 'invalid-identifier',
 


### PR DESCRIPTION
Fixes #145